### PR TITLE
Refactor table rendering; Optional layout

### DIFF
--- a/config.php
+++ b/config.php
@@ -30,10 +30,6 @@ $PAGE->set_heading($blockname. ': '. $header);
 $PAGE->navbar->add($header);
 $PAGE->set_pagetype($blockname);
 
-if (get_config('moodle', 'block_quickmail_courselayout')) {
-    $PAGE->set_pagelayout('course');
-}
-
 $changed = false;
 
 if ($reset) {

--- a/email.php
+++ b/email.php
@@ -56,10 +56,6 @@ $PAGE->set_heading($blockname . ': '.$header);
 $PAGE->set_url('/course/view.php', array('courseid' => $courseid));
 $PAGE->set_pagetype($blockname);
 
-if (get_config('moodle', 'block_quickmail_courselayout')) {
-    $PAGE->set_pagelayout('course');
-}
-
 $PAGE->requires->js('/blocks/quickmail/js/jquery.js');
 $PAGE->requires->js('/blocks/quickmail/js/selection.js');
 

--- a/emaillog.php
+++ b/emaillog.php
@@ -62,10 +62,6 @@ $PAGE->set_heading($blockname . ': ' . $header);
 $PAGE->set_url('/course/view.php', array('id' => $courseid));
 $PAGE->set_pagetype($blockname);
 
-if (get_config('moodle', 'block_quickmail_courselayout')) {
-    $PAGE->set_pagelayout('course');
-}
-
 $dbtable = 'block_quickmail_' . $type;
 
 $params = array('userid' => $userid, 'courseid' => $courseid);

--- a/settings.php
+++ b/settings.php
@@ -33,11 +33,4 @@ if($ADMIN->fulltree) {
             array_map($only_names, $roles)
         )
     );
-
-    $settings->add(
-        new admin_setting_configcheckbox('block_quickmail_courselayout',
-            quickmail::_s('courselayout'),
-            quickmail::_s('courselayout_desc'), 0
-        )
-    );
 }

--- a/signature.php
+++ b/signature.php
@@ -78,9 +78,6 @@ $PAGE->set_context($context);
 if ($course) {
     $PAGE->set_course($course);
     $PAGE->set_url('/course/view.php', array('id' => $courseid));
-    if (get_config('moodle', 'block_quickmail_courselayout')) {
-        $PAGE->set_pagelayout('course');
-    }
 }
 
 $PAGE->navbar->add($blockname);


### PR DESCRIPTION
I wanted to refactor the table rendering on the Moodle form page. I was hoping that would fix the fixed width issue, but it seems to be at the Moodle form level, and not the table level. It's refactored to core table renderings, so we're aboard that ship.

To fix the fixed width issue, I've added what I believe to be a harmless admin setting to render the Quickmail block pages under the  _course_ layout.

@rrusso, can you please take a look at it? I want to get your opinion on both the UI changes, and the layout option.

The aim was to fix #12.
