### PR TITLE
Do not include default values for null fields

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -9,7 +9,7 @@
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true" ENUM="false" NEXT="courseid"/>
         <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" ENUM="false" PREVIOUS="id" NEXT="userid"/>
         <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" ENUM="false" PREVIOUS="courseid" NEXT="alternateid"/>
-        <FIELD NAME="alternateid" TYPE="int" LENGTH="10" NOTNULL="false" UNSIGNED="true" DEFAULT="NULL" SEQUENCE="false" ENUM="false" PREVIOUS="userid" NEXT="mailto"/>
+        <FIELD NAME="alternateid" TYPE="int" LENGTH="10" NOTNULL="false" UNSIGNED="true" SEQUENCE="false" ENUM="false" PREVIOUS="userid" NEXT="mailto"/>
         <FIELD NAME="mailto" TYPE="text" LENGTH="small" NOTNULL="true" SEQUENCE="false" ENUM="false" PREVIOUS="alternateid" NEXT="subject"/>
         <FIELD NAME="subject" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" ENUM="false" PREVIOUS="mailto" NEXT="message"/>
         <FIELD NAME="message" TYPE="text" LENGTH="small" NOTNULL="true" SEQUENCE="false" ENUM="false" PREVIOUS="subject" NEXT="attachment"/>
@@ -40,7 +40,7 @@
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true" ENUM="false" NEXT="courseid"/>
         <FIELD NAME="courseid" TYPE="int" LENGTH="11" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" ENUM="false" PREVIOUS="id" NEXT="userid"/>
         <FIELD NAME="userid" TYPE="int" LENGTH="11" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" ENUM="false" PREVIOUS="courseid" NEXT="alternateid"/>
-        <FIELD NAME="alternateid" TYPE="int" LENGTH="10" NOTNULL="false" UNSIGNED="true" DEFAULT="NULL" SEQUENCE="false" ENUM="false" PREVIOUS="userid" NEXT="mailto"/>
+        <FIELD NAME="alternateid" TYPE="int" LENGTH="10" NOTNULL="false" UNSIGNED="true" SEQUENCE="false" ENUM="false" PREVIOUS="userid" NEXT="mailto"/>
         <FIELD NAME="mailto" TYPE="text" LENGTH="medium" NOTNULL="false" SEQUENCE="false" ENUM="false" PREVIOUS="alternateid" NEXT="subject"/>
         <FIELD NAME="subject" TYPE="text" LENGTH="small" NOTNULL="false" SEQUENCE="false" ENUM="false" PREVIOUS="mailto" NEXT="message"/>
         <FIELD NAME="message" TYPE="text" LENGTH="medium" NOTNULL="false" SEQUENCE="false" ENUM="false" PREVIOUS="subject" NEXT="attachment"/>


### PR DESCRIPTION
I attempted to install latest master in 2.3 and it crashed, complaining about invalid default values. I removed the NULL specifications from the two fields that specified them and it installed properly.
