### PR TITLE
Quickmail: fix upgrade failure point

### DIFF
--- a/config_form.php
+++ b/config_form.php
@@ -13,7 +13,7 @@ class config_form extends moodleform {
                 'courseid' => $this->_customdata['courseid'],
                 'reset' => 1
             )), quickmail::_s('reset')
-        ); 
+        );
         $mform->addElement('static', 'reset', '', $reset_link);
 
         $student_select = array(0 => get_string('no'), 1 => get_string('yes'));

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -39,13 +39,15 @@ function xmldb_block_quickmail_upgrade($oldversion) {
 
         $table->addKey($key);
 
-        $dbman->create_table($table);
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
 
         foreach (array('log', 'drafts') as $table) {
             // Define field alternateid to be added to block_quickmail_log
             $table = new xmldb_table('block_quickmail_' . $table);
             $field = new xmldb_field('alternateid', XMLDB_TYPE_INTEGER, '10',
-                XMLDB_UNSIGNED, null, null, 'NULL', 'userid');
+                XMLDB_UNSIGNED, null, null, null, 'userid');
 
             // Conditionally launch add field alternateid
             if (!$dbman->field_exists($table, $field)) {


### PR DESCRIPTION
This is similar to #34 and was discovered during a 2.2-2.3 upgrade. Also includes a safety check on the table creation and an unrelated whitespace fix.
