### PR TITLE
Improved attachment filearea

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -59,5 +59,26 @@ function xmldb_block_quickmail_upgrade($oldversion) {
         upgrade_block_savepoint($result, 2012021014, 'quickmail');
     }
 
+    if ($oldversion < 2012061112) {
+        // Restructure database references to the new filearea locations
+        foreach (array('log', 'drafts') as $type) {
+            $params = array(
+                'component' => 'block_quickmail_' . $type,
+                'filearea' => 'attachment'
+            );
+
+            $attachments = $DB->get_records('files', $params);
+
+            foreach ($attachments as $attachment) {
+                $attachment->filearea = 'attachment_' . $type;
+                $attachment->component = 'block_quickmail';
+
+                $result = $result && $DB->update_record('files', $attachment);
+            }
+        }
+
+        upgrade_block_savepoint($result, 2012061112, 'quickmail');
+    }
+
     return $result;
 }

--- a/email.php
+++ b/email.php
@@ -223,7 +223,7 @@ if ($form->is_cancelled()) {
 
         // An instance id is needed before storing the file repository
         file_save_draft_area_files($data->attachments, $context->id,
-            'block_quickmail_'.$table, 'attachment', $data->id);
+            'block_quickmail', 'attachment_' . $table, $data->id);
 
         // Send emails
         if (isset($data->send)) {
@@ -283,7 +283,10 @@ if ($form->is_cancelled()) {
 if (empty($email->attachments)) {
     if(!empty($type)) {
         $attachid = file_get_submitted_draft_itemid('attachment');
-        file_prepare_draft_area($attachid, $context->id, 'block_quickmail_'.$type, 'attachment', $typeid);
+        file_prepare_draft_area(
+            $attachid, $context->id, 'block_quickmail',
+            'attachment_' . $type, $typeid
+        );
         $email->attachments = $attachid;
     }
 }

--- a/emaillog.php
+++ b/emaillog.php
@@ -73,7 +73,7 @@ $count = $DB->count_records($dbtable, $params);
 
 switch ($action) {
     case "confirm":
-        if(quickmail::cleanup($dbtable, $typeid)) {
+        if (quickmail::cleanup($dbtable, $context->id, $typeid)) {
             $url = new moodle_url('/blocks/quickmail/emaillog.php', array(
                 'courseid' => $courseid,
                 'type' => $type

--- a/version.php
+++ b/version.php
@@ -2,4 +2,4 @@
 
 // Written at Louisiana State University
 
-$plugin->version = 2012021014;
+$plugin->version = 2012061112;


### PR DESCRIPTION
This enhancement successfully upgrades the Moodle backend to support the new attachment filearea's. Preliminary tests look good. After an additional round of testing, I'll merge it in.

The reasons for this switch are as follows:
1. Attachments can be backed up without kludgy hacks
2. One step closer to eliminating zipped email attachments
