### PR TITLE
Fixes #73: replace call to get_role_users with sql.

### DIFF
--- a/email.php
+++ b/email.php
@@ -91,9 +91,18 @@ $users = array();
 $users_to_roles = array();
 $users_to_groups = array();
 
-$everyone = get_role_users(0, $context, false, 'u.id, u.firstname, u.lastname,
-    u.email, u.mailformat, u.maildisplay, r.id AS roleid',
-    'u.lastname, u.firstname');
+// List everyone with role in course.
+// 
+// Note that users with multiple roles will be squashed into one
+// record.
+
+$sql = "SELECT DISTINCT u.id, u.firstname, u.lastname,
+            u.email, u.mailformat, u.suspended, u.maildisplay
+              FROM {role_assignments} ra
+              JOIN {user} u ON u.id = ra.userid
+              JOIN {role} r ON ra.roleid = r.id
+             WHERE (ra.contextid = ? ) ";
+$everyone = $DB->get_records_sql($sql, array($context->id));
 
 foreach ($everyone as $userid => $user) {
     $usergroups = groups_get_user_groups($courseid, $userid);


### PR DESCRIPTION
Hi - this may not be the best fix, I mentioned some alternatives in issue#73 . All I want to do is stop the call to get_role_users from triggering the debugging call/warning in get_records_sql when we have users with multiple role assignments in the course.

This patch would apply to tag v1.2.8 not the head of master although doing that is easy enough as well.

Rest of commit message:
The call to get_role_users was triggering a call to 'debugging'
in get_records_sql because the call could return more than one
instance of the same user (u.id) if that user had >1 role assignments
in a course.
The debugging message generated is:
"Did you remember to make the first column something unique in your
call to get_records? Duplicate value '2736' found in column 'id'. "
