### PR TITLE
As described in #68, limits the ability for users to delete quickmail hi...

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -37,5 +37,12 @@ $capabilities = array(
         'archetypes' => array(
             'manager' => CAP_ALLOW,
         )
+    ),
+    'block/quickmail:candelete' => array(
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => array(
+            'manager' => CAP_ALLOW,
+        )
     )
 );

--- a/emaillog.php
+++ b/emaillog.php
@@ -39,7 +39,9 @@ $can_send = has_capability('block/quickmail:cansend', $context);
 
 $proper_permission = ($can_send or !empty($config['allowstudents']));
 
-$can_delete = ($can_send or ($proper_permission and $type == 'drafts'));
+//managers can delete by capability 'candelete'; 
+//those with 'cansend' (incl students, if $config['allowstudents']) can only delete drafts; 
+$can_delete = (has_capability('block/quickmail:candelete', $context) or ($can_send and $type == 'drafts') or ($proper_permission and $type == 'drafts'));
 
 // Stops students from tempering with history
 if (!$proper_permission or (!$can_delete and in_array($action, $valid_actions))) {

--- a/version.php
+++ b/version.php
@@ -1,4 +1,4 @@
 <?php
 
 // Written at Louisiana State University
-$plugin->version = 2012061112;
+$plugin->version = 2013021111;


### PR DESCRIPTION
...story.
fixes #68
I am unclear as to which role(s) we would prefer to give this capability to.
This commit sets it to the role 'Manager', though 'Course Creator' might be more appropriate.
