### PR TITLE
Add block/quickmail:addinstance capability for Moodle 2.5

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -44,5 +44,18 @@ $capabilities = array(
         'archetypes' => array(
             'manager' => CAP_ALLOW,
         )
+    ),
+    'block/quickmail:addinstance' => array(
+        'riskbitmask' => RISK_SPAM,
+
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_BLOCK,
+        'archetypes' => array(
+            'manager' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'coursecreator' => CAP_ALLOW
+        ),
+
+        'clonepermissionsfrom' => 'moodle/site:manageblocks'
     )
 );

--- a/version.php
+++ b/version.php
@@ -1,4 +1,4 @@
 <?php
 
 // Written at Louisiana State University
-$plugin->version = 2013021111;
+$plugin->version = 2013051500;


### PR DESCRIPTION
Lack of this capability throws a Developer warning in Moodle 2.5.
