### PR TITLE
Added missing en lang string for quickmail:candelete

### DIFF
--- a/lang/en/block_quickmail.php
+++ b/lang/en/block_quickmail.php
@@ -5,6 +5,7 @@ $string['quickmail:cansend'] = "Allows users to send email through Quickmail";
 $string['quickmail:canconfig'] = "Allows users to configure Quickmail instance.";
 $string['quickmail:canimpersonate'] = "Allows users to log in as other users and view history.";
 $string['quickmail:allowalternate'] = "Allows users to add an alternate email for courses.";
+$string['quickmail:candelete'] = "Allows users to delete email from history.";
 $string['backup_history'] = 'Include Quickmail History';
 $string['restore_history'] = 'Restore Quickmail History';
 $string['overwrite_history'] = 'Overwrite Quickmail History';


### PR DESCRIPTION
Missing string has following text: "Allows users to delete email from history."

Let me know if I understood the capability incorrectly.
