### PR TITLE
Fixed strict standards warning on delete_dialog

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -232,7 +232,7 @@ abstract class quickmail {
         }
     }
 
-    function delete_dialog($courseid, $type, $typeid) {
+    static function delete_dialog($courseid, $type, $typeid) {
         global $CFG, $DB, $USER, $OUTPUT;
 
         $email = $DB->get_record('block_quickmail_'.$type, array('id' => $typeid));


### PR DESCRIPTION
When deleting a draft, we get a strict standards warning (see attached screenshot).

![screen shot 2013-08-27 at 11 17 28 am](https://f.cloud.github.com/assets/349765/1036953/18d82be0-0f46-11e3-8c4b-e31874820820.png)

To fix the bug, I just made quickmail::delete_dialog() a static method.
