### PR TITLE
Disable multiple instances of this block

### DIFF
--- a/block_quickmail.php
+++ b/block_quickmail.php
@@ -15,6 +15,14 @@ class block_quickmail extends block_list {
     function has_config() {
         return true;
     }
+    /**
+     * Disable multiple instances of this block
+     * @return bool Returns false
+     */
+    function instance_allow_multiple() {
+        return false;
+    }
+    
     function get_content() {
         global $CFG, $COURSE, $OUTPUT;
 


### PR DESCRIPTION
A teacher added (by mistake) two instances of this block to the course and we got a backup error.

I think this block should have only one instance per course. Am I right ?
