### PR TITLE
Update upgrade.php

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -159,6 +159,7 @@ function xmldb_block_quickmail_upgrade($oldversion) {
         upgrade_block_savepoint($result, 2012061112, 'quickmail');
     }
     if ($oldversion < 2012061112) {
+        require_once( require_once(__DIR__.'/upgradelib.php') );
     	migrate_quickmail_20();
     }
 


### PR DESCRIPTION
Upgrading Quickmail when upgrading Moodle from 2.2.6 to 2.5.3 complained about function 'migrate_quickmail_20' missing.  I read that the require_once was needed, and it fixed the issue.

I am pushing this back to you guys to see if its needed!
