### PR TITLE
Allow site admins to disallow student access to Quickmail

### DIFF
--- a/config_form.php
+++ b/config_form.php
@@ -18,8 +18,13 @@ class config_form extends moodleform {
 
         $student_select = array(0 => get_string('no'), 1 => get_string('yes'));
 
-        $mform->addElement('select', 'allowstudents',
-            quickmail::_s('allowstudents'), $student_select);
+        $allowstudents = get_config('moodle', 'block_quickmail_allowstudents');
+        if ($allowstudents != -1) {
+            // If we disallow "Allow students to use Quickmail" at the site
+            // level, then disallow the config to be set at the course level.
+            $mform->addElement('select', 'allowstudents',
+                quickmail::_s('allowstudents'), $student_select);
+        }
 
         $roles =& $mform->addElement('select', 'roleselection',
             quickmail::_s('select_roles'), $this->_customdata['roles']);

--- a/lang/en/block_quickmail.php
+++ b/lang/en/block_quickmail.php
@@ -54,6 +54,7 @@ $string['qm_contents'] = 'Download File Contents';
 
 // Config form strings
 $string['allowstudents'] = 'Allow students to use Quickmail';
+$string['allowstudentsdesc'] = 'Allow students to use Quickmail. If you choose "Never", the block cannot be configured to allow students access at the course level.';
 $string['select_roles'] = 'Roles to filter by';
 $string['reset'] = 'Restore System Defaults';
 

--- a/lib.php
+++ b/lib.php
@@ -198,6 +198,11 @@ abstract class quickmail {
             $receipt = get_config($m, 'block_quickmail_receipt');
             $ferpa = get_config($m, 'block_quickmail_ferpa');
 
+            // Convert Never (-1) to No (0) in case site config is changed.
+            if ($allowstudents == -1) {
+                $allowstudents = 0;
+            }
+
             $config = array(
                 'allowstudents' => $allowstudents,
                 'roleselection' => $roleselection,
@@ -205,6 +210,14 @@ abstract class quickmail {
                 'receipt' => $receipt,
                 'ferpa' => $ferpa
             );
+
+        } else {
+            // See if allow students is disabled at the site level.
+            $allowstudents = get_config('moodle', 'block_quickmail_allowstudents');
+            if ($allowstudents == -1) {
+                $config['allowstudents'] = 0;
+            }
+			$config['ferpa'] = get_config('moodle', 'block_quickmail_ferpa');
         }
 
         return $config;

--- a/settings.php
+++ b/settings.php
@@ -7,12 +7,13 @@ defined('MOODLE_INTERNAL') || die;
 if($ADMIN->fulltree) {
     require_once $CFG->dirroot . '/blocks/quickmail/lib.php';
 
-    $select = array(0 => get_string('no'), 1 => get_string('yes'));
+    $select = array(-1 => get_string('never'), 0 => get_string('no'), 1 => get_string('yes'));
 
     $allow = quickmail::_s('allowstudents');
+    $allowdesc = quickmail::_s('allowstudentsdesc');
     $settings->add(
         new admin_setting_configselect('block_quickmail_allowstudents',
-            $allow, $allow, 0, $select
+            $allow, $allowdesc, 0, $select
         )
     );
 

--- a/tests/behat/student_usage.feature
+++ b/tests/behat/student_usage.feature
@@ -1,0 +1,60 @@
+@block @block_quickmail
+Feature: Control student usage of Quickmail
+  In order to prevent or allow student usage of Quickmail block
+  As a system administrator
+  I need be able to set a site config setting to control student usage or leave
+  the decision to the instructor
+
+  Background:
+    Given the following "courses" exists:
+      | fullname | shortname | category | groupmode |
+      | Course 1 | C1 | 0 | 1 |
+    And the following "users" exists:
+      | username | firstname | lastname | email |
+      | teacher1 | Teacher | 1 | teacher1@asd.com |
+      | student1 | Student | 1 | student1@asd.com |
+    And the following "course enrolments" exists:
+      | user | course | role |
+      | teacher1 | C1 | editingteacher |
+      | student1 | C1 | student |
+    And I log in as "admin"
+    And I follow "Course 1"
+    And I turn editing mode on
+    When I add the "Quickmail" block
+    Then I should see "Compose New Email" in the "Quickmail" "block"
+
+  Scenario: Leaving "Allow student to use Quickmail" at default values
+    Given I click on "Configuration" "link" in the "Quickmail" "block"
+    Then I should see "Allow students to use Quickmail"
+    And the "Allow students to use Quickmail" field should match "No" value
+
+  Scenario: Disabling "Allow student to use Quickmail" at the site level
+    Given I set the following administration settings values:
+      | Allow students to use Quickmail | Never |
+    And I log out
+    When I log in as "teacher1"
+    And I follow "Course 1"
+    And I click on "Configuration" "link" in the "Quickmail" "block"
+    Then I should not see "Allow students to use Quickmail"
+
+  Scenario: Allow access at course level, then disable it at site level
+    Given I click on "Configuration" "link" in the "Quickmail" "block"
+    Then I fill the moodle form with:
+        | Allow students to use Quickmail | Yes |
+    And I press "Save changes"
+    And I log out
+    When I log in as "student1"
+    And I follow "Course 1"
+    Then I should see "Compose New Email" in the "Quickmail" "block"
+    And I click on "Compose New Email" "link" in the "Quickmail" "block"
+    And I should see "Subject"
+    And I should see "Message"
+    Then I log out
+    When I log in as "admin"
+    And I set the following administration settings values:
+      | Allow students to use Quickmail | Never |
+    And I log out
+    When I log in as "student1"
+    And I follow "Course 1"
+    Then I should not see "Quickmail"
+


### PR DESCRIPTION
- Added new config setting to allow site admins to disallow student access to Quickmail
- Added behat tests

I added a new config setting for block_quickmail_allowstudents called "Never (-1)". If it is set, then it will not show the config setting to "Allow students to use Quickmail" in the block configuration and will override any previously set value for the setting.

I also added a related Behat test to ensure that the feature is working.
