### PR TITLE
Add the capacity to send emails to users who have a user context role

### DIFF
--- a/lang/en/block_quickmail.php
+++ b/lang/en/block_quickmail.php
@@ -51,6 +51,10 @@ $string['download_open'] = 'Open Downloads';
 $string['receipt'] = 'Receive a copy';
 $string['receipt_help'] = 'Receive a copy of the email being sent';
 
+// Strings for user context.
+$string['role_of_users'] = '{$a->role} of {$a->userlist}';
+$string['separator'] = ', ';
+
 $string['no_alternates'] = 'No alternate emails found for {$a->fullname}. Continue to make one.';
 
 $string['select_users'] = 'Select Users ...';

--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,6 @@
 
 #page-block-quickmail select[multiple] {
    min-width: 250px;
-   max-width: 250px;
 }
 
 #page-block-quickmail .mform {
@@ -40,6 +39,7 @@
 #page-block-quickmail .emailtable .r1 .c1 {
     text-align: center;
     vertical-align: middle;
+    padding: 0 10px;
 }
 
 #page-block-quickmail .emailtable .r1 .c2 div {


### PR DESCRIPTION
The role is relative to a user of the course.

This is useful for sending emails to parents or mentors of students of the courses.
See this documentation for more details about the parent role:
https://docs.moodle.org/29/en/Parent_role
