### PR TITLE
Allow folder attachments to be retrieved when viewing a quickmail draft.

### DIFF
--- a/email.php
+++ b/email.php
@@ -348,7 +348,7 @@ if (empty($email->attachments)) {
     if (!empty($type)) {
         $attachid = file_get_submitted_draft_itemid('attachment');
         file_prepare_draft_area(
-            $attachid, $context->id, 'block_quickmail', 'attachment_' . $type, $typeid
+            $attachid, $context->id, 'block_quickmail', 'attachment_' . $type, $typeid, $editor_options
         );
         $email->attachments = $attachid;
     }


### PR DESCRIPTION
We've experienced the issue where a user attaches a directory to a quickmail then saves the draft.  Upon opening the draft at a later time, the folder no longer appears.  By not passing the $editor_options to file_prepare_draft_area on line 351, that function assumes no directories are allowed and therefore ignores directories.  
