### PR TITLE
Add course full name option to the subject prepend course name setting

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -45,7 +45,8 @@ if($ADMIN->fulltree) {
     $options = array(
         0 => get_string('none'),
         'idnumber' => get_string('idnumber'),
-        'shortname' => get_string('shortname')
+        'shortname' => get_string('shortname'),
+        'fullname' => get_string('fullname')
     );
 
     $settings->add(


### PR DESCRIPTION
This pull request contains a commit which adds the option to prepend the course full name to the subject instead of the idnumber or short name.

![screen shot 2016-07-23 at 17 11 37](https://cloud.githubusercontent.com/assets/4180675/17078640/8c019f88-50f8-11e6-94ba-280d3e5dfdbc.png)
