### PR TITLE
Added $plugin->component = 'block_quickmail'; in version.php

### DIFF
--- a/version.php
+++ b/version.php
@@ -6,3 +6,4 @@ $plugin->version = 2015122912;
 $plugin->requires = 2013051400;
 $plugin->release = "v1.5.0";
 $plugin->maturity = MATURITY_STABLE; 
+$plugin->component = 'block_quickmail';     // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
Otherwise it wouldn't let you install the block in Moodle 3.1 without throwing an error.

Would you consider at least adding this line in your plugin's version.php?
Setting up new Moodle instances based on Git sources otherwise pretty much looks like everything would work out swimmingly exept of your contribution. That's a very bad backlash on such a great tool it is.

Best regards!