### PR TITLE
Fixed broken attachment URLs

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -92,10 +92,8 @@ abstract class quickmail {
             if (empty($text)) {
                 $text = $filename;
             }
-            $url = new moodle_url('/pluginfile.php', array(
-                'forcedownload' => 1,
-                'file' => "/$base_url/$filename"
-            ));
+
+            $url = moodle_url::make_file_url('/pluginfile.php', "$base_url/$filename", true);
 
             //to prevent double encoding of ampersands in urls for our plaintext users,
             //we use the out() method of moodle_url


### PR DESCRIPTION
In the latest version of Quickmail (1.5.5) found in the Moodle.org plugin database I ran into broken attachment URLs. Changing creation of the attachment URL to use the moodle_url make_file_url method solved the problem.