### PR TITLE
Missing $plugin->component added

### DIFF
--- a/version.php
+++ b/version.php
@@ -4,5 +4,6 @@
 //
 $plugin->version = 2016092701;
 $plugin->requires = 2013051400;
+$plugin->component = 'block_quickmail';
 $plugin->release = "v1.5.0";
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
On trying to add the plugin to Moodle 3.2 an error was thrown asking for the code I've now added.