### PR TITLE
Prevents filepicker and text editor overflow

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -55,7 +55,6 @@
    float:none;
    position:center;
    overflow:hidden;
-   min-width:900px;
    width:100%;
    text-align:left;
    margin:auto;


### PR DESCRIPTION
This min-width causes the filepicker and text editor fields to overflow when page width is at and under ~1200px. I see that you've got responsive improvements in the works but have used this for a client so thought I'd make the pull request anyway.